### PR TITLE
adding specification to enums to distinguish between bitfields and pure

### DIFF
--- a/Components/Cpp/HeaderFormatter.cpp
+++ b/Components/Cpp/HeaderFormatter.cpp
@@ -263,7 +263,8 @@ void HeaderFormatter::_definition(std::ostream& stream, Model::EnumRef enum_) co
 
     stream << "};" << endl << endl;
 
-    if(enum_->isBitfield()) {
+    if( enum_->isBitfield() )
+    {
         std::string operators( "|&^" );
         for ( char &op :operators )
         {

--- a/Components/Cpp/HeaderFormatter.cpp
+++ b/Components/Cpp/HeaderFormatter.cpp
@@ -263,13 +263,15 @@ void HeaderFormatter::_definition(std::ostream& stream, Model::EnumRef enum_) co
 
     stream << "};" << endl << endl;
 
-    std::string operators( "|&^" );
-    for ( char &op :operators )
-    {
-        stream << "inline " << name(enum_) << " operator" << op << "( " << name(enum_) << " a, " << name(enum_) << " b )" << endl
-            << "{" << endl;
-        filter(stream).push<indent>(config.indentData) << "return static_cast<" << name(enum_) << ">(static_cast<int>(a) " << op << " static_cast<int>(b));" << endl;
-        stream << "}" << endl << endl;
+    if(enum_->isBitfield()) {
+        std::string operators( "|&^" );
+        for ( char &op :operators )
+        {
+            stream << "inline " << name(enum_) << " operator" << op << "( " << name(enum_) << " a, " << name(enum_) << " b )" << endl
+                   << "{" << endl;
+            filter(stream).push<indent>(config.indentData) << "return static_cast<" << name(enum_) << ">(static_cast<int>(a) " << op << " static_cast<int>(b));" << endl;
+            stream << "}" << endl << endl;
+        }
     }
 }
 

--- a/Components/StandardParser.cpp
+++ b/Components/StandardParser.cpp
@@ -43,6 +43,7 @@ const char *StandardParser::FLAG_STATIC             = "static";
 const char *StandardParser::FLAG_CONST              = "const";
 const char *StandardParser::FLAG_SYNCHRONOUS        = "synchronous";
 const char *StandardParser::FLAG_VALUETYPE          = "valueType";
+const char *StandardParser::FLAG_BITFIELD           = "bitfield";
 const char *StandardParser::KEY_SUPER               = "super";
 
 const char *StandardParser::KEY_ID                  = "id";
@@ -344,6 +345,11 @@ void StandardParser::parseEnum(const YAML::Node &node, const ElementRef &parent,
             {
                 throw runtime_error(addSectionToException(KEY_VALUES));
             }
+        }
+
+        if (checkNode(node, FLAG_BITFIELD))
+        {
+            newEnum->setBitfield(node[FLAG_BITFIELD].as<bool>());
         }
     }
     catch (const runtime_error &e)

--- a/Components/StandardParser.hpp
+++ b/Components/StandardParser.hpp
@@ -65,6 +65,7 @@ public:
     static const char *FLAG_CONST;
     static const char *FLAG_SYNCHRONOUS;
     static const char *FLAG_VALUETYPE;
+    static const char *FLAG_BITFIELD;
     /** @} */
 
     /**

--- a/Model/Enum.cpp
+++ b/Model/Enum.cpp
@@ -31,6 +31,14 @@ std::vector<Enum::ValueRef> Enum::values() const
     return _values;
 }
 
+bool Enum::isBitfield() {
+    return _isBitfield;
+}
+
+void Enum::setBitfield(bool isBitfield) {
+    _isBitfield = isBitfield;
+}
+
 void Enum::clone(const ObjectRef &clonedObject) const
 {
     using namespace std;

--- a/Model/Enum.cpp
+++ b/Model/Enum.cpp
@@ -7,6 +7,7 @@ const char* Enum::TYPE_NAME = "Enum";
 
 Enum::Enum()
 {
+    _isBitfield = false;
 }
 
 Enum::~Enum()
@@ -31,11 +32,13 @@ std::vector<Enum::ValueRef> Enum::values() const
     return _values;
 }
 
-bool Enum::isBitfield() {
+bool Enum::isBitfield()
+{
     return _isBitfield;
 }
 
-void Enum::setBitfield(bool isBitfield) {
+void Enum::setBitfield(bool isBitfield)
+{
     _isBitfield = isBitfield;
 }
 

--- a/Model/Enum.hpp
+++ b/Model/Enum.hpp
@@ -26,11 +26,16 @@ public:
     void addValue(const ValueRef &value);
     std::vector<ValueRef> values() const;
 
+public:
+    bool isBitfield();
+    void setBitfield(bool isBitfield);
+
 protected:
     void clone(const ObjectRef &clonedObject) const override;
 
 private:
     std::vector<ValueRef> _values;
+    bool _isBitfield = false;
 };
 
 typedef std::shared_ptr<Enum> EnumRef;

--- a/Model/Enum.hpp
+++ b/Model/Enum.hpp
@@ -35,7 +35,7 @@ protected:
 
 private:
     std::vector<ValueRef> _values;
-    bool _isBitfield = false;
+    bool _isBitfield;
 };
 
 typedef std::shared_ptr<Enum> EnumRef;


### PR DESCRIPTION
Enums die als Bitfields konstruiert sind sollten mit 
bitfield: true
in der yaml Datei markiert werden.
