### PR TITLE
Change Objective-C enum member format

### DIFF
--- a/Components/ObjectiveC/FormatterBase.cpp
+++ b/Components/ObjectiveC/FormatterBase.cpp
@@ -30,7 +30,7 @@ FormatterBase::FormatterBase()
                 NameConfig<Parameter>        { NameStyle::LOWER_CAMELCASE, "", false },
                 NameConfig<Struct>           { NameStyle::UPPER_CAMELCASE, "", false },
                 NameConfig<Enum>             { NameStyle::UPPER_CAMELCASE, "", false },
-                NameConfig<Enum::Value>      { NameStyle::UPPERCASE, "_", false },
+                NameConfig<Enum::Value>      { NameStyle::UPPER_CAMELCASE, "", false },
                 NameConfig<Class>            { NameStyle::UPPER_CAMELCASE, "", false },
                 NameConfig<Class::Constant>  { NameStyle::UPPER_CAMELCASE, "", false },
                 NameConfig<Class::Event>     { NameStyle::UPPER_CAMELCASE, "", false },

--- a/Components/ObjectiveC/HeaderFormatter.cpp
+++ b/Components/ObjectiveC/HeaderFormatter.cpp
@@ -279,7 +279,7 @@ void HeaderFormatter::_definition(std::ostream& stream, Model::Enum::ValueRef va
         stream << doc(value->doc());
     }
 
-    stream << name(value) << " = 0x" << std::hex << static_cast<std::uint64_t>(value->value());
+    stream << qname(value) << " = 0x" << std::hex << static_cast<std::uint64_t>(value->value());
 }
 
 } } } } // namespace: Everbase::InterfaceCompiler::Components::ObjectiveC


### PR DESCRIPTION
Changes generated ObjectiveC code from

```
typedef enum {
    NONE = 0x0
} ECSPermissionMode;
```

to

```
typedef enum {
    ECSPermissionModeNone = 0x0
} ECSPermissionMode;
```

This avoids errors with redefinition of the enumerator if multiple enums have the same member names. The camel-case name seems, to me, to be Objective-C-ish.
